### PR TITLE
release_v0.0.4

### DIFF
--- a/.github/workflows/linux_unit_tests.yml
+++ b/.github/workflows/linux_unit_tests.yml
@@ -51,32 +51,32 @@ jobs:
         name: Running Graphs Tests
         run: |
           cd unpacked_sdist
-          pytest facilyst/tests/graphs_tests -n 2 --durations 0 --cov=facilyst --junitxml=test-reports/${{matrix.command}}-junit.xml
+          pytest facilyst/tests/graphs_tests -n 2 --durations 0 --cov=facilyst --junitxml=unpacked_sdist/test-reports/${{matrix.command}}-junit.xml
       - if: ${{ matrix.command == 'Mocks' }}
         name: Running Mocks Tests
         run: |
           cd unpacked_sdist
-          pytest facilyst/tests/mock_tests -n 2 --durations 0 --cov=facilyst --junitxml=test-reports/${{matrix.command}}-junit.xml
+          pytest facilyst/tests/mock_tests -n 2 --durations 0 --cov=facilyst --junitxml=unpacked_sdist/test-reports/${{matrix.command}}-junit.xml
       - if: ${{ matrix.command == 'Models' }}
         name: Running Models Tests
         run: |
           cd unpacked_sdist
-          pytest facilyst/tests/models_tests -n 2 --durations 0 --cov=facilyst --junitxml=test-reports/${{matrix.command}}-junit.xml
+          pytest facilyst/tests/models_tests -n 2 --durations 0 --cov=facilyst --junitxml=unpacked_sdist/test-reports/${{matrix.command}}-junit.xml
       - if: ${{ matrix.command == 'Preprocessors' }}
         name: Running Preprocessors Tests
         run: |
           cd unpacked_sdist
-          pytest facilyst/tests/preprocessing_tests -n 2 --durations 0 --cov=facilyst --junitxml=test-reports/${{matrix.command}}-junit.xml
+          pytest facilyst/tests/preprocessing_tests -n 2 --durations 0 --cov=facilyst --junitxml=unpacked_sdist/test-reports/${{matrix.command}}-junit.xml
       - if: ${{ matrix.command == 'Utils' }}
         name: Running Utils Tests
         run: |
           cd unpacked_sdist
-          pytest facilyst/tests/utils_tests facilyst/tests/test_version.py -n 2 --durations 0 --cov=facilyst --junitxml=test-reports/${{matrix.command}}-junit.xml
+          pytest facilyst/tests/utils_tests facilyst/tests/test_version.py -n 2 --durations 0 --cov=facilyst --junitxml=unpacked_sdist/test-reports/${{matrix.command}}-junit.xml
       - name: Upload pytest duration artifact
         uses: actions/upload-artifact@v2
         with:
           name: pytest-duration-report
-          path: test-reports/${{matrix.command}}-junit.xml
+          path: unpacked_sdist/test-reports/${{matrix.command}}-junit.xml
       - name: install coverage
         run: pip install coverage
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -28,8 +28,3 @@ how to plot it in a visually appealing way, I wanted a library that could provid
 Install from [PyPI](https://pypi.org/project/facilyst/)
 
 `pip install facilyst`
-
-
-## Version - 0.0.2
-
-This is a work in progress and there are many features to be added.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,16 @@ Future Release
     * Documentation Changes
     * Testing Changes
     * CI/CD Changes
+
+
+v0.0.4 May 1, 2022
+==================
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+    * CI/CD Changes
         * Added ``linux_unit_tests_without_extra_dependencies`` GitHub Action to check that all tests pass on MRs without extra dependencies :pr:`52`
         * Made ``Hyperopt`` a required dependency :pr:`48`
 

--- a/facilyst/tests/test_version.py
+++ b/facilyst/tests/test_version.py
@@ -2,4 +2,4 @@ from facilyst import __version__
 
 
 def test_version():
-    assert __version__ == "0.0.3"
+    assert __version__ == "0.0.4"

--- a/facilyst/version.py
+++ b/facilyst/version.py
@@ -1,2 +1,2 @@
 """Current facilyst version."""
-__version__ = "0.0.3"
+__version__ = "0.0.4"


### PR DESCRIPTION
v0.0.4 May 1, 2022

- CI/CD Changes
    - Added ``linux_unit_tests_without_extra_dependencies`` GitHub Action to check that all tests pass on MRs without extra dependencies #52 
    - Made ``Hyperopt`` a required dependency #48 